### PR TITLE
fix: charger status not loaded in widget mode when not authenticated

### DIFF
--- a/app/static/js/charger_info.js
+++ b/app/static/js/charger_info.js
@@ -1,5 +1,6 @@
 function fetchStatuses() {
-    fetch("/dashboard/statuses")
+    const url = WIDGET_MODE ? "/dashboard/widget/statuses" : "/dashboard/statuses";
+    fetch(url)
         .then(res => res.json())
         .then(data => {
             for (const [chargerId, info] of Object.entries(data)) {

--- a/app/templates/base_charger.html
+++ b/app/templates/base_charger.html
@@ -23,6 +23,7 @@
     {% block content %}{% endblock %}
 
     <script>
+        let WIDGET_MODE = true;
         function formatDuration(seconds) {
             const hours = Math.floor(seconds / 3600);
             const minutes = Math.floor((seconds % 3600) / 60);

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -334,6 +334,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
     let API_KEY = "{{ user.api_key }}";
+    let WIDGET_MODE = false;
     const selected_charger_id = {{ selected_charger | tojson }};
 
     const dailyCtx = document.getElementById('dailyChart').getContext('2d');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new dashboard widget mode that displays the latest status for all chargers, available only when the system is in read-only mode.

* **Improvements**
  * The application now automatically selects the appropriate endpoint for fetching charger statuses based on widget mode.
  * Added a global variable to distinguish between widget and standard dashboard modes in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->